### PR TITLE
Big query

### DIFF
--- a/app/createDepartures.js
+++ b/app/createDepartures.js
@@ -6,7 +6,7 @@ import { uniqBy, toString } from 'lodash';
 import { upsert } from './upsert';
 import { getPrimaryConstraint } from './getPrimaryConstraint';
 import { createNotNullFilter } from './utils/notNullFilter';
-import PQueue from 'p-queue';
+import { BATCH_SIZE } from '../constants';
 
 const knex = getKnex();
 
@@ -26,80 +26,72 @@ let createDeparturesKey = (constraint) => {
   };
 };
 
-async function departuresQuery(route, pool) {
+async function departuresQuery() {
+  let pool = await getPool(5);
+
   let request = pool.request();
-  
-  let maxDate = format(addMonths(new Date(), 1), 'yyyy-MM-dd')
-  let minDate = format(subYears(new Date(), 1), 'yyyy-MM-dd')
+  request.stream = true;
+
+  let maxDate = format(addMonths(new Date(), 1), 'yyyy-MM-dd');
+  let minDate = format(subYears(new Date(), 1), 'yyyy-MM-dd');
 
   // language=TSQL
-  let { recordset = [] } = await request.query(`
-        SELECT TRIM(lah.reitunnus) route_id,
-              CAST(lah.lhsuunta AS smallint) direction,
-              lah.lhpaivat day_type,
-              CAST(lah.lhlahaik AS varchar) origin_departure_time,
-              CAST(ROW_NUMBER() over (
-                 PARTITION BY lah.reitunnus, lah.lhsuunta, lah.lhpaivat, lah.lavoimast, vpa.vastunnus
-                 ORDER BY vpa.vaslaika
-              ) AS int) departure_id,
-              COALESCE(NULLIF(TRIM(lah.lhajotyyppi), ''), 'N') extra_departure,
-              COALESCE(lah.lhkaltyyppi, 'ET') equipment_type,
-              lah.kohtunnus procurement_unit_id,
-              CAST(lah.termaika AS smallint) terminal_time,
-              CAST(lah.elpymisaika AS smallint) recovery_time,
-              COALESCE(CAST(lah.pakollkaltyyppi AS smallint), 0) equipment_required,
-              lah.junanumero train_number,
-              aik.lavoimast date_begin,
-              aik.laviimvoi date_end,
-              vpa.vastunnus stop_id,
-              CAST(vpa.vaslaika AS varchar) departure_time,
-              CAST(vpa.vastaika AS varchar) arrival_time,
-              COALESCE(CAST(vpa.vaslvrkvht AS smallint), CAST(lah.lhvrkvht AS smallint), 0) is_next_day,
-              CAST(vpa.vastvrkvht AS smallint) arrival_is_next_day,
-              kk.liitunnus operator_id,
-              COALESCE(lv.kookoodi, '0') trunk_color_required,
-              aik.laviimpvm date_modified
-        FROM dbo.jr_lahto lah
-           LEFT JOIN dbo.jr_valipisteaika vpa on lah.reitunnus = vpa.reitunnus
-                and lah.lhsuunta = vpa.lhsuunta
-                and lah.lhpaivat = vpa.lhpaivat
-                and lah.lhlahaik = vpa.lhlahaik
-                and lah.lavoimast = vpa.lavoimast
-                and lah.lhvrkvht = vpa.lhvrkvht
-           LEFT JOIN dbo.jr_aikataulu aik on lah.lavoimast = aik.lavoimast
-                and lah.reitunnus = aik.reitunnus
-           LEFT JOIN dbo.jr_kilpailukohd kk on lah.kohtunnus = kk.kohtunnus
-           LEFT JOIN dbo.jr_linja_vaatimus lv on lah.reitunnus = lv.lintunnus
-        WHERE lah.reitunnus = '${route.reitunnus}'
-          AND lah.lhsuunta = '${route.suusuunta}'
-          AND lah.lavoimast >= ${minDate}
-          AND lah.lavoimast <= ${maxDate}
-        ORDER BY CAST(lah.lhlahaik AS decimal)
-    `);
+  request.query(`
+      WITH departure_routes as (
+          SELECT DISTINCT TRIM(reitunnus) reitunnus, suusuunta, lnkalkusolmu
+          FROM dbo.jr_reitinlinkki
+          WHERE relpysakki != 'E'
+            AND suuvoimast >= '${minDate}'
+            AND reljarjnro = 1
+      )
+      SELECT TRIM(lah.reitunnus) route_id,
+            CAST(lah.lhsuunta AS smallint) direction,
+            lah.lhpaivat day_type,
+            CAST(lah.lhlahaik AS varchar) origin_departure_time,
+            route.lnkalkusolmu origin_stop_id,
+            CAST(ROW_NUMBER() over (
+               PARTITION BY lah.reitunnus, lah.lhsuunta, lah.lhpaivat, lah.lavoimast, vpa.vastunnus
+               ORDER BY vpa.vaslaika
+            ) AS int) departure_id,
+            COALESCE(NULLIF(TRIM(lah.lhajotyyppi), ''), 'N') extra_departure,
+            COALESCE(lah.lhkaltyyppi, 'ET') equipment_type,
+            lah.kohtunnus procurement_unit_id,
+            CAST(lah.termaika AS smallint) terminal_time,
+            CAST(lah.elpymisaika AS smallint) recovery_time,
+            COALESCE(CAST(lah.pakollkaltyyppi AS smallint), 0) equipment_required,
+            lah.junanumero train_number,
+            aik.lavoimast date_begin,
+            aik.laviimvoi date_end,
+            COALESCE(vpa.vastunnus, route.lnkalkusolmu) stop_id,
+            COALESCE(CAST(vpa.vaslaika AS varchar), CAST(lah.lhlahaik AS varchar)) departure_time,
+            COALESCE(CAST(vpa.vastaika AS varchar), CAST(lah.lhlahaik AS varchar)) arrival_time,
+            COALESCE(CAST(vpa.vaslvrkvht AS smallint), CAST(lah.lhvrkvht AS smallint), 0) is_next_day,
+            COALESCE(CAST(vpa.vastvrkvht AS smallint), CAST(lah.lhvrkvht AS smallint), 0) arrival_is_next_day,
+            kk.liitunnus operator_id,
+            COALESCE(lv.kookoodi, '0') trunk_color_required,
+            aik.laviimpvm date_modified
+      FROM departure_routes route
+         LEFT JOIN dbo.jr_lahto lah on lah.reitunnus = route.reitunnus
+              AND lah.lhsuunta = route.suusuunta
+         LEFT JOIN dbo.jr_valipisteaika vpa on lah.reitunnus = vpa.reitunnus
+              and lah.lhsuunta = vpa.lhsuunta
+              and lah.lhpaivat = vpa.lhpaivat
+              and lah.lhlahaik = vpa.lhlahaik
+              and lah.lavoimast = vpa.lavoimast
+              and lah.lhvrkvht = vpa.lhvrkvht
+         LEFT JOIN dbo.jr_aikataulu aik on lah.lavoimast = aik.lavoimast
+              and lah.reitunnus = aik.reitunnus
+         LEFT JOIN dbo.jr_kilpailukohd kk on lah.kohtunnus = kk.kohtunnus
+         LEFT JOIN dbo.jr_linja_vaatimus lv on lah.reitunnus = lv.lintunnus
+      WHERE lah.lavoimast >= '${minDate}'
+        AND lah.lavoimast <= '${maxDate}'
+      ORDER BY CAST(lah.lhlahaik AS decimal)
+  `);
 
-  return recordset;
+  return request;
 }
 
-async function getRoutes() {
-  let pool = await getPool(1);
-  let request = pool.request();
-
-  // language=TSQL
-  let { recordset = [] } = await request.query(`
-      SELECT DISTINCT TRIM(reitunnus) reitunnus, suusuunta, lnkalkusolmu
-      FROM dbo.jr_reitinlinkki
-      WHERE relpysakki != 'E'
-        AND suuvoimast >= '2020-01-01'
-        AND reljarjnro = 1
-    `);
-
-  return recordset;
-}
-
-export async function createDepartures(schemaName) {
-  let syncTime = process.hrtime();
-  let routes = await getRoutes();
-
+async function createRowsProcessor(schemaName) {
   let columnSchema;
   let constraint;
 
@@ -117,92 +109,106 @@ export async function createDepartures(schemaName) {
   let notNullFilter = createNotNullFilter(constraint, columnSchema);
   let createRowKey = createDeparturesKey(constraint);
 
-  let syncQueue = new PQueue({
-    concurrency: 10,
-    autoStart: true,
+  return async (rows) => {
+    /*let firstDepartures = uniqBy(
+      rows,
+      (dep) => `${dep.origin_departure_time}_${dep.day_type}_${dep.date_begin}`
+    );
+  
+    let originDepartures = firstDepartures.map((dep) => ({
+      ...dep,
+      departure_time: dep.origin_departure_time,
+      arrival_time: dep.origin_departure_time,
+      stop_id: route.lnkalkusolmu,
+    }));
+  
+    let rawDepartures = [...originDepartures, ...rows];*/
+
+    let departures = rows.map((depRow) => {
+      let {
+        origin_departure_time,
+        departure_time,
+        arrival_time,
+        trunk_color_required,
+        is_next_day,
+        equipment_required,
+        arrival_is_next_day,
+        ...depProps
+      } = depRow;
+
+      let [origin_hours = -1, origin_minutes = -1] = (origin_departure_time || '')
+        .split('.')
+        .map((num) => parseInt(num, 10));
+
+      let [hours = -1, minutes = -1] = (departure_time || '')
+        .split('.')
+        .map((num = '-1') => parseInt(num, 10));
+
+      let [arrival_hours = -1, arrival_minutes = -1] = (arrival_time || '')
+        .split('.')
+        .map((num = '-1') => parseInt(num, 10));
+
+      return {
+        ...depProps,
+        origin_hours: origin_hours,
+        origin_minutes: origin_minutes,
+        hours: hours,
+        minutes: minutes,
+        arrival_hours: arrival_hours,
+        arrival_minutes: arrival_minutes,
+        trunk_color_required: trunk_color_required === '2',
+        is_next_day: is_next_day === 1,
+        arrival_is_next_day: arrival_is_next_day === 1,
+        equipment_required: equipment_required === 1,
+      };
+    });
+
+    let validDepartures = departures.filter((dep) => notNullFilter(dep));
+    let uniqDepartures = uniqBy(validDepartures, createRowKey);
+
+    if (uniqDepartures.length !== 0) {
+      await upsert(schemaName, 'departure', uniqDepartures);
+    }
+  };
+}
+
+export async function createDepartures(schemaName) {
+  let syncTime = process.hrtime();
+  console.log(`[Status]   Importing departures.`);
+
+  await new Promise(async (resolve, reject) => {
+    let request = await departuresQuery();
+    let rowsProcessor = await createRowsProcessor(schemaName);
+
+    let rows = [];
+
+    async function processRows() {
+      try {
+        await rowsProcessor(rows);
+      } catch (err) {
+        console.log(`[Error]    Insert error on table departure`, err);
+      }
+
+      rows = [];
+      request.resume();
+    }
+
+    request.on('row', async (row) => {
+      rows.push(row);
+
+      if (rows.length >= BATCH_SIZE) {
+        request.pause();
+        await processRows();
+      }
+    });
+
+    request.on('done', async () => {
+      await processRows();
+      resolve();
+    });
+
+    request.on('error', reject);
   });
-
-  for (let route of routes) {
-    let routeName = `${route.reitunnus}/${route.suusuunta}/${route.lnkalkusolmu}`;
-
-    syncQueue
-      .add(async () => {
-        console.log(`[Status]   Importing ${routeName}`);
-
-        let pool = await getPool(1);
-        let rows = await departuresQuery(route, pool);
-
-        let firstDepartures = uniqBy(
-          rows,
-          (dep) => `${dep.origin_departure_time}_${dep.day_type}_${dep.date_begin}`
-        );
-
-        let originDepartures = firstDepartures.map((dep) => ({
-          ...dep,
-          departure_time: dep.origin_departure_time,
-          arrival_time: dep.origin_departure_time,
-          stop_id: route.lnkalkusolmu,
-        }));
-
-        let rawDepartures = [...originDepartures, ...rows];
-
-        let departures = rawDepartures.map((depRow) => {
-          let {
-            origin_departure_time,
-            departure_time,
-            arrival_time,
-            trunk_color_required,
-            is_next_day,
-            equipment_required,
-            arrival_is_next_day,
-            ...depProps
-          } = depRow;
-
-          let [origin_hours = -1, origin_minutes = -1] = (origin_departure_time || '')
-            .split('.')
-            .map((num) => parseInt(num, 10));
-
-          let [hours = -1, minutes = -1] = (departure_time || '')
-            .split('.')
-            .map((num = '-1') => parseInt(num, 10));
-
-          let [arrival_hours = -1, arrival_minutes = -1] = (arrival_time || '')
-            .split('.')
-            .map((num = '-1') => parseInt(num, 10));
-
-          return {
-            origin_stop_id: route.lnkalkusolmu,
-            ...depProps,
-            origin_hours: origin_hours,
-            origin_minutes: origin_minutes,
-            hours: hours,
-            minutes: minutes,
-            arrival_hours: arrival_hours,
-            arrival_minutes: arrival_minutes,
-            trunk_color_required: trunk_color_required === '2',
-            is_next_day: is_next_day === 1,
-            arrival_is_next_day: arrival_is_next_day === 1,
-            equipment_required: equipment_required === 1,
-          };
-        });
-
-        console.log(`[Status]   Departures of ${routeName} fetched`);
-
-        let validDepartures = departures.filter((dep) => notNullFilter(dep));
-        let uniqDepartures = uniqBy(validDepartures, createRowKey);
-        
-        if (uniqDepartures.length !== 0) {
-          await upsert(schemaName, 'departure', uniqDepartures);
-        }
-
-        console.log(`[Status]   Departures of ${routeName} inserted.`);
-      })
-      .catch((err) => {
-        console.log(`[Error]    Sync error on table ${routeName}`, err);
-      });
-  }
-
-  await syncQueue.onIdle();
 
   logTime('[Status]   Departures table created.', syncTime);
 }

--- a/app/sqlScripts/create_write_schema.sql
+++ b/app/sqlScripts/create_write_schema.sql
@@ -125,6 +125,25 @@ create index lahto_lahtoaika
 create index suunta
     on ak_kaavion_lahto (suunta);
 
+create table ak_kalusto
+(
+    katyyppi varchar(2) not null
+        constraint ak_kalusto_pk
+            primary key,
+    kamatlatt varchar,
+    kaselite varchar(40),
+    jarjnro smallint,
+    perustaja varchar(8),
+    perustpvm timestamp with time zone,
+    muuttaja varchar(8),
+    muutospvm timestamp with time zone
+);
+
+alter table ak_kalusto owner to postgres;
+
+create index ak_kalusto_katyyppi_index
+    on ak_kalusto (katyyppi);
+
 create table jr_ajoneuvo
 (
     id varchar not null,

--- a/schema.sql
+++ b/schema.sql
@@ -127,6 +127,25 @@ create index lahto_lahtoaika
 create index suunta
     on ak_kaavion_lahto (suunta);
 
+create table ak_kalusto
+(
+    katyyppi varchar(2) not null
+        constraint ak_kalusto_pk
+            primary key,
+    kamatlatt varchar,
+    kaselite varchar(40),
+    jarjnro smallint,
+    perustaja varchar(8),
+    perustpvm timestamp with time zone,
+    muuttaja varchar(8),
+    muutospvm timestamp with time zone
+);
+
+alter table ak_kalusto owner to postgres;
+
+create index ak_kalusto_katyyppi_index
+    on ak_kalusto (katyyppi);
+
 create table jr_ajoneuvo
 (
     id varchar not null,
@@ -985,3 +1004,64 @@ create index jr_valipisteaika_reitunnus_index
 
 create index jr_valipisteaika_reitunnus_lhsuunta_index
     on jr_valipisteaika (reitunnus, lhsuunta);
+
+create table departure
+(
+    stop_id varchar(7) not null,
+    origin_stop_id varchar(7) not null,
+    route_id varchar(6) not null,
+    direction smallint not null,
+    day_type varchar(2) not null,
+    departure_id smallint not null,
+    is_next_day boolean not null,
+    hours smallint not null,
+    minutes smallint not null,
+    origin_hours smallint not null,
+    origin_minutes smallint not null,
+    arrival_is_next_day boolean not null,
+    arrival_hours smallint not null,
+    arrival_minutes smallint not null,
+    date_begin date not null,
+    date_end date not null,
+    extra_departure varchar(2) default 'N'::character varying not null,
+    terminal_time smallint,
+    recovery_time smallint,
+    equipment_type varchar(2),
+    equipment_required smallint,
+    procurement_unit_id varchar(12),
+    operator_id varchar(6),
+    available_operators varchar(20),
+    trunk_color_required smallint,
+    constraint departure_pkey
+        primary key (route_id, direction, date_begin, date_end, hours, minutes, stop_id, day_type, extra_departure)
+);
+
+alter table departure owner to postgres;
+
+create index departure_stop_id_index
+    on departure (stop_id);
+
+create index departure_route_id_index
+    on departure (route_id);
+
+create index departure_day_type_index
+    on departure (day_type);
+
+create index departure_departure_id_index
+    on departure (departure_id);
+
+create index departure_date_begin_index
+    on departure (date_begin);
+
+create index departure_route_id_direction_stop_id_idx
+    on departure (route_id, direction, stop_id);
+
+create index departure_origin_index
+    on departure (stop_id, route_id, direction, date_begin, date_end, departure_id, day_type);
+
+create index departure_stop_id_day_type
+    on departure (stop_id, day_type);
+
+create index departure_origin_time_index
+    on departure (origin_hours, origin_minutes);
+

--- a/tables.lst
+++ b/tables.lst
@@ -4,6 +4,7 @@ ak_aikataulukausi
 ak_kaavio
 ak_kaavion_lahto
 ak_kaavion_suoritteet
+ak_kalusto
 jr_ajoneuvo
 jr_kilpailukohd
 jr_konserni
@@ -26,7 +27,7 @@ jr_raidekalusto
 jr_korvpvkalent
 jr_eritpvkalent
 jr_piste
-jr_aikataulu
-jr_lahto
+#jr_aikataulu
+#jr_lahto
 #jr_valipisteaika
 jr_liik_kilpa_suhde


### PR DESCRIPTION
Refactor the source query for the departures table.

Instead of first querying for a list of routes and making many departure queries, do one big departures query and stream the results  into Postgres.